### PR TITLE
Fix (clippy) warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ iccv4-enabled = []
 cmyk = []
 
 [dependencies]
-libc = {version = "0.2", optional = true }
+libc = { version = "0.2", optional = true }
 
 [build-dependencies]
 rustc_version = "0.2"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -232,9 +232,9 @@ impl ModularTransform for Clut3x3 {
             let device_r: f32 = src[0];
             let device_g: f32 = src[1];
             let device_b: f32 = src[2];
-            let linear_r: f32 = lut_interp_linear_float(device_r, &input_clut_table_r);
-            let linear_g: f32 = lut_interp_linear_float(device_g, &input_clut_table_g);
-            let linear_b: f32 = lut_interp_linear_float(device_b, &input_clut_table_b);
+            let linear_r: f32 = lut_interp_linear_float(device_r, input_clut_table_r);
+            let linear_g: f32 = lut_interp_linear_float(device_g, input_clut_table_g);
+            let linear_b: f32 = lut_interp_linear_float(device_b, input_clut_table_b);
             let x: i32 = (linear_r * (self.grid_size as i32 - 1) as f32).floor() as i32;
             let y: i32 = (linear_g * (self.grid_size as i32 - 1) as f32).floor() as i32;
             let z: i32 = (linear_b * (self.grid_size as i32 - 1) as f32).floor() as i32;
@@ -269,11 +269,11 @@ impl ModularTransform for Clut3x3 {
             let b_y2: f32 = lerp(b_x3, b_x4, y_d);
             let clut_b: f32 = lerp(b_y1, b_y2, z_d);
             let pcs_r: f32 =
-                lut_interp_linear_float(clut_r, &self.output_clut_table[0].as_ref().unwrap());
+                lut_interp_linear_float(clut_r, self.output_clut_table[0].as_ref().unwrap());
             let pcs_g: f32 =
-                lut_interp_linear_float(clut_g, &self.output_clut_table[1].as_ref().unwrap());
+                lut_interp_linear_float(clut_g, self.output_clut_table[1].as_ref().unwrap());
             let pcs_b: f32 =
-                lut_interp_linear_float(clut_b, &self.output_clut_table[2].as_ref().unwrap());
+                lut_interp_linear_float(clut_b, self.output_clut_table[2].as_ref().unwrap());
             dest[0] = clamp_float(pcs_r);
             dest[1] = clamp_float(pcs_g);
             dest[2] = clamp_float(pcs_b);
@@ -307,10 +307,10 @@ impl ModularTransform for Clut4x3 {
         let input_clut_table_3 = self.input_clut_table[3].as_ref().unwrap();
         for (dest, src) in dest.chunks_exact_mut(3).zip(src.chunks_exact(4)) {
             debug_assert!(self.grid_size as i32 >= 1);
-            let linear_x: f32 = lut_interp_linear_float(src[0], &input_clut_table_0);
-            let linear_y: f32 = lut_interp_linear_float(src[1], &input_clut_table_1);
-            let linear_z: f32 = lut_interp_linear_float(src[2], &input_clut_table_2);
-            let linear_w: f32 = lut_interp_linear_float(src[3], &input_clut_table_3);
+            let linear_x: f32 = lut_interp_linear_float(src[0], input_clut_table_0);
+            let linear_y: f32 = lut_interp_linear_float(src[1], input_clut_table_1);
+            let linear_z: f32 = lut_interp_linear_float(src[2], input_clut_table_2);
+            let linear_w: f32 = lut_interp_linear_float(src[3], input_clut_table_3);
 
             let x: i32 = (linear_x * (self.grid_size as i32 - 1) as f32).floor() as i32;
             let y: i32 = (linear_y * (self.grid_size as i32 - 1) as f32).floor() as i32;
@@ -352,11 +352,11 @@ impl ModularTransform for Clut4x3 {
             let clut_b = quadlinear(b_tbl);
 
             let pcs_r =
-                lut_interp_linear_float(clut_r, &self.output_clut_table[0].as_ref().unwrap());
+                lut_interp_linear_float(clut_r, self.output_clut_table[0].as_ref().unwrap());
             let pcs_g =
-                lut_interp_linear_float(clut_g, &self.output_clut_table[1].as_ref().unwrap());
+                lut_interp_linear_float(clut_g, self.output_clut_table[1].as_ref().unwrap());
             let pcs_b =
-                lut_interp_linear_float(clut_b, &self.output_clut_table[2].as_ref().unwrap());
+                lut_interp_linear_float(clut_b, self.output_clut_table[2].as_ref().unwrap());
             dest[0] = clamp_float(pcs_r);
             dest[1] = clamp_float(pcs_g);
             dest[2] = clamp_float(pcs_b);
@@ -530,9 +530,9 @@ impl ModularTransform for GammaLut {
             let in_r: f32 = src[0];
             let in_g: f32 = src[1];
             let in_b: f32 = src[2];
-            out_r = lut_interp_linear(in_r as f64, &self.output_gamma_lut_r.as_ref().unwrap());
-            out_g = lut_interp_linear(in_g as f64, &self.output_gamma_lut_g.as_ref().unwrap());
-            out_b = lut_interp_linear(in_b as f64, &self.output_gamma_lut_b.as_ref().unwrap());
+            out_r = lut_interp_linear(in_r as f64, self.output_gamma_lut_r.as_ref().unwrap());
+            out_g = lut_interp_linear(in_g as f64, self.output_gamma_lut_g.as_ref().unwrap());
+            out_b = lut_interp_linear(in_b as f64, self.output_gamma_lut_b.as_ref().unwrap());
             dest[0] = clamp_float(out_r);
             dest[1] = clamp_float(out_g);
             dest[2] = clamp_float(out_b);
@@ -787,9 +787,9 @@ fn modular_transform_create_input(input: &Profile) -> Option<Vec<Box<dyn Modular
     if let Some(A2B0) = &input.A2B0 {
         let lut_transform;
         if A2B0.num_input_channels == 4 {
-            lut_transform = Some(modular_transform_create_lut4x3(&A2B0));
+            lut_transform = Some(modular_transform_create_lut4x3(A2B0));
         } else {
-            lut_transform = modular_transform_create_lut(&A2B0);
+            lut_transform = modular_transform_create_lut(A2B0);
         }
         if let Some(lut_transform) = lut_transform {
             transforms.extend(lut_transform);

--- a/src/gtest.rs
+++ b/src/gtest.rs
@@ -6,10 +6,10 @@ mod gtest {
         transform_util::lut_inverse_interp16, Intent::Perceptual,
     };
     use libc::c_void;
-    #[cfg(all(target_arch = "arm", std_arch))]
-    use std::arch::is_arm_feature_detected;
     #[cfg(all(target_arch = "aarch64", std_arch))]
     use std::arch::is_aarch64_feature_detected;
+    #[cfg(all(target_arch = "arm", std_arch))]
+    use std::arch::is_arm_feature_detected;
     use std::ptr::null_mut;
 
     #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]

--- a/src/iccread.rs
+++ b/src/iccread.rs
@@ -489,7 +489,7 @@ fn read_tag_s15Fixed16ArrayType(src: &mut MemSource, tag: &Tag) -> Matrix {
 }
 fn read_tag_XYZType(src: &mut MemSource, index: &TagIndex, tag_id: u32) -> XYZNumber {
     let mut num = XYZNumber { X: 0, Y: 0, Z: 0 };
-    let tag = find_tag(&index, tag_id);
+    let tag = find_tag(index, tag_id);
     if let Some(tag) = tag {
         let offset: u32 = tag.offset;
         let type_0: u32 = read_u32(src, offset as usize);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 /*! A pure Rust color management library.
 */
 
+#![allow(clippy::needless_late_init)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
@@ -8,10 +9,7 @@
 // These are needed for the neon SIMD code and can be removed once the MSRV supports the
 // instrinsics we use
 #![cfg_attr(feature = "neon", feature(stdsimd))]
-#![cfg_attr(
-    feature = "neon",
-    feature(aarch64_target_feature, arm_target_feature, raw_ref_op)
-)]
+#![cfg_attr(feature = "neon", feature(arm_target_feature, raw_ref_op))]
 
 /// These values match the Rendering Intent values from the ICC spec
 #[repr(u32)]

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -53,12 +53,12 @@ use crate::{
     },
 };
 
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-#[cfg(all(target_arch = "arm", feature = "neon", std_arch))]
-use std::arch::is_arm_feature_detected;
 #[cfg(all(target_arch = "aarch64", feature = "neon", std_arch))]
 use std::arch::is_aarch64_feature_detected;
+#[cfg(all(target_arch = "arm", feature = "neon", std_arch))]
+use std::arch::is_arm_feature_detected;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 pub const PRECACHE_OUTPUT_SIZE: usize = 8192;
 pub const PRECACHE_OUTPUT_MAX: usize = PRECACHE_OUTPUT_SIZE - 1;
@@ -414,15 +414,15 @@ unsafe extern "C" fn qcms_transform_data_gray_template_lut<I: GrayFormat, F: For
 
         let out_device_r: f32 = lut_interp_linear(
             linear as f64,
-            &(*transform).output_gamma_lut_r.as_ref().unwrap(),
+            (*transform).output_gamma_lut_r.as_ref().unwrap(),
         );
         let out_device_g: f32 = lut_interp_linear(
             linear as f64,
-            &(*transform).output_gamma_lut_g.as_ref().unwrap(),
+            (*transform).output_gamma_lut_g.as_ref().unwrap(),
         );
         let out_device_b: f32 = lut_interp_linear(
             linear as f64,
-            &(*transform).output_gamma_lut_b.as_ref().unwrap(),
+            (*transform).output_gamma_lut_b.as_ref().unwrap(),
         );
         *dest.add(F::kRIndex) = clamp_u8(out_device_r * 255f32);
         *dest.add(F::kGIndex) = clamp_u8(out_device_g * 255f32);
@@ -1057,7 +1057,7 @@ unsafe fn qcms_transform_data_template_lut<F: Format>(
 
         let out_device_r: f32 = lut_interp_linear(
             out_linear_r as f64,
-            &(*transform).output_gamma_lut_r.as_ref().unwrap(),
+            (*transform).output_gamma_lut_r.as_ref().unwrap(),
         );
         let out_device_g: f32 = lut_interp_linear(
             out_linear_g as f64,


### PR DESCRIPTION
This was originally intended to be a change to that:

![](https://cdn.magicuser.cf/9xXXJ7j.png)

but I also found other clippy warnings and decided to eliminate them

I also did cargo fmt