### PR TITLE
Reduce cost of bounds checks in transforms

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -159,7 +159,7 @@ impl ModularTransform for XYZtoLAB {
 
 struct ClutOnly {
     clut: Box<[f32]>,
-    grid_size: u16,
+    grid_size: u8,
 }
 
 impl ModularTransform for ClutOnly {
@@ -223,7 +223,7 @@ impl ModularTransform for ClutOnly {
 struct Clut3x3 {
     input_clut_table: [Option<Vec<f32>>; 3],
     clut: Option<Vec<f32>>,
-    grid_size: u16,
+    grid_size: u8,
     output_clut_table: [Option<Vec<f32>>; 3],
 }
 impl ModularTransform for Clut3x3 {
@@ -297,7 +297,7 @@ impl ModularTransform for Clut3x3 {
 struct Clut4x3 {
     input_clut_table: [Option<Vec<f32>>; 4],
     clut: Option<Vec<f32>>,
-    grid_size: u16,
+    grid_size: u8,
     output_clut_table: [Option<Vec<f32>>; 3],
 }
 impl ModularTransform for Clut4x3 {
@@ -656,7 +656,7 @@ fn modular_transform_create_mAB(lut: &lutmABType) -> Option<Vec<Box<dyn ModularT
         // Prepare CLUT
         transforms.push(Box::new(ClutOnly {
             clut: clut_table.into(),
-            grid_size: lut.num_grid_points[0] as u16,
+            grid_size: lut.num_grid_points[0],
         }));
     }
 
@@ -726,7 +726,7 @@ fn modular_transform_create_lut(lut: &lutType) -> Option<Vec<Box<dyn ModularTran
         assert_eq!(clut_length, lut.clut_table.len());
         transform.clut = Some(lut.clut_table.clone());
 
-        transform.grid_size = lut.num_clut_grid_points as u16;
+        transform.grid_size = lut.num_clut_grid_points;
         // Prepare output curves
         transform.output_clut_table[0] =
             Some(lut.output_table[0..lut.num_output_table_entries as usize].to_vec());
@@ -775,7 +775,7 @@ fn modular_transform_create_lut4x3(lut: &lutType) -> Vec<Box<dyn ModularTransfor
     assert_eq!(clut_length, lut.clut_table.len());
     transform.clut = Some(lut.clut_table.clone());
 
-    transform.grid_size = lut.num_clut_grid_points as u16;
+    transform.grid_size = lut.num_clut_grid_points;
     // Prepare output curves
     transform.output_clut_table[0] =
         Some(lut.output_table[0..lut.num_output_table_entries as usize].to_vec());

--- a/src/transform_util.rs
+++ b/src/transform_util.rs
@@ -114,16 +114,16 @@ fn lut_interp_linear_precache_output(input_value: u32, table: &[u16]) -> u8 {
 }
 /* value must be a value between 0 and 1 */
 //XXX: is the above a good restriction to have?
+#[inline]
 pub fn lut_interp_linear_float(mut value: f32, table: &[f32]) -> f32 {
-    value *= (table.len() - 1) as f32;
+    let max_val = table.len() - 1;
+    value *= max_val as f32;
 
-    let upper: i32 = value.ceil() as i32;
-    let lower: i32 = value.floor() as i32;
+    let upper = value.ceil();
+    let lower = value.floor();
     //XXX: can we be more performant here?
-    value = (table[upper as usize] as f64 * (1.0f64 - (upper as f32 - value) as f64)
-        + (table[lower as usize] * (upper as f32 - value)) as f64) as f32;
-    /* scale the value */
-    value
+    (table[max_val.min(upper as usize)] as f64 * (1.0 - (upper - value) as f64)
+        + (table[max_val.min(lower as usize)] * (upper - value)) as f64) as f32
 }
 
 fn compute_curve_gamma_table_type1(gamma_table: &mut [f32; 256], gamma: u16) {


### PR DESCRIPTION
According to llvm-mca estimate, the 4x3 transform function

before:

uOps Per Cycle:    2.70
IPC:               1.97
Block RThroughput: 159.3

after:

uOps Per Cycle:    3.48
IPC:               2.69
Block RThroughput: 279.8
